### PR TITLE
Use the appropriate phy-mode for the EIC7700 MACs

### DIFF
--- a/arch/riscv/boot/dts/eswin/eic7700.dtsi
+++ b/arch/riscv/boot/dts/eswin/eic7700.dtsi
@@ -347,7 +347,7 @@
 			interrupt-parent = <&plic0>;
 			interrupt-names = "macirq";
 			interrupts = <61>;
-			phy-mode = "rgmii";
+			phy-mode = "rgmii-txid";
 			numa-node-id = <0>;
 			id = <0>;
 			status = "disabled";
@@ -375,7 +375,7 @@
 			interrupt-parent = <&plic0>;
 			interrupt-names = "macirq";
 			interrupts = <70>;
-			phy-mode = "rgmii";
+			phy-mode = "rgmii-txid";
 			numa-node-id = <0>;
 			id = <1>;
 			status = "disabled";


### PR DESCRIPTION
This could be board specific but set globally it currently works for all the avialable boards used for Fedora development and fixes 1G on the StarPro64

When I say it works , I've tested the StarPro64 and the Megrez,  would be good to test the Premiere P550